### PR TITLE
Fix crash with vlsAlloc

### DIFF
--- a/callstack.cpp
+++ b/callstack.cpp
@@ -245,7 +245,7 @@ void CallStack::dump(BOOL showInternalFrames, UINT start_frame) const
             {
                 isFrameInternal = true;
                 // Don't show frames in files internal to the heap.
-                g_symbolLock.Leave();
+                //g_symbolLock.Leave();
             }
         }
 
@@ -692,7 +692,8 @@ VOID SafeCallStack::getStackTrace (UINT32 maxdepth, const context_t& context)
 
     // Walk the stack.
     CriticalSectionLocker cs(g_stackWalkLock);
-    while (count < maxdepth) {
+	g_symbolLock.Enter();
+	while (count < maxdepth) {
         count++;
         DbgTrace(L"dbghelp32.dll %i: StackWalk64\n", GetCurrentThreadId());
         if (!StackWalk64(architecture, g_currentProcess, g_currentThread, &frame, &currentContext, NULL,
@@ -708,4 +709,5 @@ VOID SafeCallStack::getStackTrace (UINT32 maxdepth, const context_t& context)
         // Push this frame's program counter onto the CallStack.
         push_back((UINT_PTR)frame.AddrPC.Offset);
     }
+	g_symbolLock.Leave();
 }

--- a/vld.cpp
+++ b/vld.cpp
@@ -589,6 +589,9 @@ VOID VisualLeakDetector::attachToLoadedModules (ModuleSet *newmodules)
             // should not, therefore, attach to itself.
             continue;
         }
+		if (_wcsicmp(TEXT("KernelBase.dll"), modulename) == 0) {
+			continue;
+		}
 
         // increase reference count to module
         HMODULE modulelocal = NULL;

--- a/vld.cpp
+++ b/vld.cpp
@@ -102,8 +102,9 @@ VisualLeakDetector::VisualLeakDetector ()
     _set_error_mode(_OUT_TO_STDERR);
 
     // Initialize configuration options and related private data.
-    _wcsnset_s(m_forcedModuleList, MAXMODULELISTLENGTH, '\0', _TRUNCATE);
-    m_maxDataDump    = 0xffffffff;
+	_wcsnset_s(m_forcedModuleList, MAXMODULELISTLENGTH, '\0', _TRUNCATE);
+	_wcsnset_s(m_excludedModuleList, MAXMODULELISTLENGTH, '\0', _TRUNCATE);
+	m_maxDataDump = 0xffffffff;
     m_maxTraceFrames = 0xffffffff;
     m_options        = 0x0;
     m_reportFile     = NULL;
@@ -592,6 +593,9 @@ VOID VisualLeakDetector::attachToLoadedModules (ModuleSet *newmodules)
 		if (_wcsicmp(TEXT("KernelBase.dll"), modulename) == 0) {
 			continue;
 		}
+		if (_wcsicmp(TEXT("dbghelp.dll"), modulename) == 0) {
+			continue;
+		}
 
         // increase reference count to module
         HMODULE modulelocal = NULL;
@@ -633,7 +637,11 @@ VOID VisualLeakDetector::attachToLoadedModules (ModuleSet *newmodules)
                     if (wcsstr(m_forcedModuleList, modulename) != NULL) {
                         // Exclude this module from leak detection.
                          moduleFlags |= VLD_MODULE_EXCLUDED;
-                    }
+					}
+					else if (wcsstr(m_excludedModuleList, modulename) != NULL) {
+						// Exclude this module from leak detection.
+						moduleFlags |= VLD_MODULE_EXCLUDED;
+					}
                 }
             }
         }
@@ -872,7 +880,10 @@ VOID VisualLeakDetector::configure ()
         m_forcedModuleList[0] = '\0';
     else
         m_options |= VLD_OPT_MODULE_LIST_INCLUDE;
-    
+
+	GetPrivateProfileString(L"Options", L"ForceExcludeModules", L"", m_excludedModuleList, MAXMODULELISTLENGTH, inipath);
+	_wcslwr_s(m_excludedModuleList, MAXMODULELISTLENGTH);
+
     // Read the report destination (debugger, file, or both).
     WCHAR filename [MAX_PATH] = {0};
     GetPrivateProfileString(L"Options", L"ReportFile", L"", filename, MAX_PATH, inipath);
@@ -1070,6 +1081,11 @@ VOID VisualLeakDetector::mapBlock (HANDLE heap, LPCVOID mem, SIZE_T size, bool c
     blockinfo->threadId = threadId;
     blockinfo->serialNumber = m_requestCurr++;
     blockinfo->size = size;
+
+	/*if (size == 368) {
+		OutputDebugStringA("Got you\n");
+	}*/
+
     blockinfo->reported = false;
 
     if (SIZE_MAX - m_totalAlloc > size)
@@ -1999,17 +2015,34 @@ SIZE_T VisualLeakDetector::ReportLeaks( )
     }
 
     // Generate a memory leak report for each heap in the process.
-    SIZE_T leaksCount = 0;
-    CriticalSectionLocker cs(m_heapMapLock);
+	SIZE_T leaksCount = 0;
+	HeapMap *heapMap = 0;
+	{
+		CriticalSectionLocker cs(m_heapMapLock);
+		heapMap = m_heapMap;
+		m_heapMap = new HeapMap;
+		m_heapMap->reserve(HEAP_MAP_RESERVE);
+	}
     bool firstLeak = true;
     Set<blockinfo_t*> aggregatedLeaks;
-    for (HeapMap::Iterator heapit = m_heapMap->begin(); heapit != m_heapMap->end(); ++heapit) {
+	for (HeapMap::Iterator heapit = heapMap->begin(); heapit != heapMap->end(); ++heapit) {
         HANDLE heap = (*heapit).first;
         UNREFERENCED_PARAMETER(heap);
         heapinfo_t* heapinfo = (*heapit).second;
         leaksCount += reportLeaks(heapinfo, firstLeak, aggregatedLeaks);
     }
-    return leaksCount;
+
+	// Free internally allocated resources used by the heapmap and blockmap.
+	for (HeapMap::Iterator heapit = heapMap->begin(); heapit != heapMap->end(); ++heapit) {
+		BlockMap *blockmap = &(*heapit).second->blockMap;
+		for (BlockMap::Iterator blockit = blockmap->begin(); blockit != blockmap->end(); ++blockit) {
+			delete (*blockit).second;
+		}
+		delete blockmap;
+	}
+	delete heapMap;
+	
+	return leaksCount;
 }
 
 SIZE_T VisualLeakDetector::ReportThreadLeaks( DWORD threadId ) 

--- a/vld_hooks.cpp
+++ b/vld_hooks.cpp
@@ -1608,7 +1608,7 @@ LPVOID VisualLeakDetector::_HeapAlloc (HANDLE heap, DWORD flags, SIZE_T size)
     // Allocate the block.
     LPVOID block = HeapAlloc(heap, flags, size);
 
-    if ((block == NULL) || !g_vld.enabled())
+	if ((block == NULL) || !g_vld.enabled() || g_symbolLock.IsLockedByCurrentThread())
         return block;
 
     tls_t* tls = g_vld.getTls();

--- a/vldint.h
+++ b/vldint.h
@@ -360,8 +360,9 @@ private:
     ////////////////////////////////////////////////////////////////////////////////
     // Private data
     ////////////////////////////////////////////////////////////////////////////////
-    WCHAR                m_forcedModuleList [MAXMODULELISTLENGTH]; // List of modules to be forcefully included in leak detection.
-    HeapMap             *m_heapMap;           // Map of all active heaps in the process.
+	WCHAR                m_forcedModuleList[MAXMODULELISTLENGTH]; // List of modules to be forcefully included in leak detection.
+	WCHAR                m_excludedModuleList[MAXMODULELISTLENGTH]; // List of modules to be forcefully excluded in leak detection.
+	HeapMap             *m_heapMap;           // Map of all active heaps in the process.
     IMalloc             *m_iMalloc;           // Pointer to the system implementation of IMalloc.
 
     SIZE_T               m_requestCurr;       // Current request number.


### PR DESCRIPTION
Found this fix somewhere, and verified it works for me (VC12, VS2013).

Else it crashes with an access violation (endless recursion)