### PR TITLE
Use CaptureContext class to simplify code in hooks

### DIFF
--- a/src/callstack.h
+++ b/src/callstack.h
@@ -125,7 +125,7 @@ protected:
     // human readable form. Currently this is only called by the dump method.
     void dumpResolved() const;
     bool isInternalModule( const PWSTR filename ) const;
-    bool isCrtStartupModule( const PWSTR filename ) const;
+    UINT isCrtStartupFunction( LPCWSTR functionName ) const;
     LPCWSTR getFunctionName(SIZE_T programCounter, DWORD64& displacement64,
         SYMBOL_INFO* functionInfo, CriticalSectionLocker<DbgHelp>& locker) const;
     DWORD resolveFunction(SIZE_T programCounter, IMAGEHLP_LINEW64* sourceInfo, DWORD displacement,

--- a/src/crtmfcpatch.h
+++ b/src/crtmfcpatch.h
@@ -183,7 +183,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__calloc_dbg (size_t      num,
     assert(pcrtxxd__calloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__calloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__calloc_dbg);
 
     return g_vld.__calloc_dbg(pcrtxxd__calloc_dbg, context, debug, num, size, type, file, line);
 }
@@ -214,7 +214,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__malloc_dbg (size_t      size,
     assert(pcrtxxd__malloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__malloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__malloc_dbg);
 
     return g_vld.__malloc_dbg(pcrtxxd__malloc_dbg, context, debug, size, type, file, line);
 }
@@ -248,7 +248,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__realloc_dbg (void       *mem,
     assert(pcrtxxd__realloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__realloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__realloc_dbg);
 
     return g_vld.__realloc_dbg(pcrtxxd__realloc_dbg, context, debug, mem, size, type, file, line);
 }
@@ -283,7 +283,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__recalloc_dbg (void       *mem,
     assert(pcrtxxd__recalloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__recalloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__recalloc_dbg);
 
     return g_vld.__recalloc_dbg(pcrtxxd__recalloc_dbg, context, debug, mem, num, size, type, file, line);
 }
@@ -299,7 +299,7 @@ char* CrtPatch<CRTVersion, debug>::crtd__strdup_dbg (const char* src,
     assert(pcrtxxd__strdup_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__strdup_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__strdup_dbg);
 
     return g_vld.__strdup_dbg(pcrtxxd__strdup_dbg, context, debug, src, type, file, line);
 }
@@ -315,7 +315,7 @@ wchar_t* CrtPatch<CRTVersion, debug>::crtd__wcsdup_dbg (const wchar_t* src,
     assert(pcrtxxd__wcsdup_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__wcsdup_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__wcsdup_dbg);
 
     return g_vld.__wcsdup_dbg(pcrtxxd__wcsdup_dbg, context, debug, src, type, file, line);
 }
@@ -346,7 +346,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__scalar_new_dbg (size_t      size,
     assert(pcrtxxd_new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_new_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_new_dbg);
 
     return g_vld.__new_dbg_crt(pcrtxxd_new_dbg, context, debug, size, type, file, line);
 }
@@ -377,7 +377,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__vector_new_dbg (size_t      size,
     assert(pcrtxxd_new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_new_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_new_dbg);
 
     return g_vld.__new_dbg_crt(pcrtxxd_new_dbg, context, debug, size, type, file, line);
 }
@@ -402,7 +402,7 @@ void* CrtPatch<CRTVersion, debug>::crtd_calloc (size_t num, size_t size)
     assert(pcrtxxd_calloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_calloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_calloc);
 
     return g_vld._calloc(pcrtxxd_calloc, context, debug, num, size);
 }
@@ -425,7 +425,7 @@ void* CrtPatch<CRTVersion, debug>::crtd_malloc (size_t size)
     assert(pcrtxxd_malloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_malloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_malloc);
 
     return g_vld._malloc(pcrtxxd_malloc, context, debug, size);
 }
@@ -450,7 +450,7 @@ void* CrtPatch<CRTVersion, debug>::crtd_realloc (void *mem, size_t size)
     assert(pcrtxxd_realloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_realloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_realloc);
 
     return g_vld._realloc(pcrtxxd_realloc, context, debug, mem, size);
 }
@@ -475,7 +475,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__recalloc (void *mem, size_t num, size_t
     assert(pcrtxxd_recalloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_recalloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_recalloc);
 
     return g_vld.__recalloc(pcrtxxd_recalloc, context, debug, mem, num, size);
 }
@@ -488,7 +488,7 @@ char* CrtPatch<CRTVersion, debug>::crtd__strdup (const char* src)
     assert(pcrtxxd_strdup);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_strdup);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_strdup);
 
     return g_vld.__strdup(pcrtxxd_strdup, context, debug, src);
 }
@@ -500,7 +500,7 @@ wchar_t* CrtPatch<CRTVersion, debug>::crtd__wcsdup (const wchar_t* src)
     assert(pcrtxxd_wcsdup);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_wcsdup);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_wcsdup);
 
     return g_vld.__wcsdup(pcrtxxd_wcsdup, context, debug, src);
 }
@@ -532,7 +532,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_malloc_dbg (size_t      size,
     assert(pcrtxxd__aligned_malloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__aligned_malloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__aligned_malloc_dbg);
 
     return g_vld.__aligned_malloc_dbg(pcrtxxd__aligned_malloc_dbg, context, debug, size, alignment, type, file, line);
 }
@@ -565,7 +565,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_malloc_dbg (size_t      
     assert(pcrtxxd__malloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__malloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__malloc_dbg);
 
     return g_vld.__aligned_offset_malloc_dbg(pcrtxxd__malloc_dbg, context, debug, size, alignment, offset, type, file, line);
 }
@@ -600,7 +600,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_realloc_dbg (void       *mem,
     assert(pcrtxxd__realloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__realloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__realloc_dbg);
 
     return g_vld.__aligned_realloc_dbg(pcrtxxd__realloc_dbg, context, debug, mem, size, alignment, type, file, line);
 }
@@ -636,7 +636,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_realloc_dbg (void       
     assert(pcrtxxd__realloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__realloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__realloc_dbg);
 
     return g_vld.__aligned_offset_realloc_dbg(pcrtxxd__realloc_dbg, context, debug, mem, size, alignment, offset, type, file, line);
 }
@@ -674,7 +674,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_recalloc_dbg (void       *mem,
     assert(pcrtxxd__recalloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__recalloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__recalloc_dbg);
 
     return g_vld.__aligned_recalloc_dbg(pcrtxxd__recalloc_dbg, context, debug, mem, num, size, alignment, type, file, line);
 }
@@ -713,7 +713,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_recalloc_dbg (void      
     assert(pcrtxxd__recalloc_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd__recalloc_dbg);
+    CaptureContext cc(context, debug, (void*)pcrtxxd__recalloc_dbg);
 
     return g_vld.__aligned_offset_recalloc_dbg(pcrtxxd__recalloc_dbg, context, debug, mem, num, size, alignment, offset, type, file, line);
 }
@@ -736,7 +736,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_malloc (size_t size, size_t ali
     assert(pcrtxxd_malloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_malloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_malloc);
 
     return g_vld.__aligned_malloc(pcrtxxd_malloc, context, debug, size, alignment);
 }
@@ -759,7 +759,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_malloc (size_t size, siz
     assert(pcrtxxd_malloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_malloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_malloc);
 
     return g_vld.__aligned_offset_malloc(pcrtxxd_malloc, context, debug, size, alignment, offset);
 }
@@ -784,7 +784,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_realloc (void *mem, size_t size
     assert(pcrtxxd_realloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_realloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_realloc);
 
     return g_vld.__aligned_realloc(pcrtxxd_realloc, context, debug, mem, size, alignment);
 }
@@ -809,7 +809,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_realloc (void *mem, size
     assert(pcrtxxd_realloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_realloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_realloc);
 
     return g_vld.__aligned_offset_realloc(pcrtxxd_realloc, context, debug, mem, size, alignment, offset);
 }
@@ -836,7 +836,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_recalloc (void *mem, size_t num
     assert(pcrtxxd_recalloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_recalloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_recalloc);
 
     return g_vld.__aligned_recalloc(pcrtxxd_recalloc, context, debug, mem, num, size, alignment);
 }
@@ -863,7 +863,7 @@ void* CrtPatch<CRTVersion, debug>::crtd__aligned_offset_recalloc (void *mem, siz
     assert(pcrtxxd_recalloc);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_recalloc);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_recalloc);
 
     return g_vld.__aligned_offset_recalloc(pcrtxxd_recalloc, context, debug, mem, num, size, alignment, offset);
 }
@@ -884,7 +884,7 @@ void* CrtPatch<CRTVersion, debug>::crtd_scalar_new (size_t size)
     assert(pcrtxxd_scalar_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_scalar_new);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_scalar_new);
 
     return g_vld._new(pcrtxxd_scalar_new, context, debug, size);
 }
@@ -905,7 +905,7 @@ void* CrtPatch<CRTVersion, debug>::crtd_vector_new (size_t size)
     assert(pcrtxxd_vector_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pcrtxxd_vector_new);
+    CaptureContext cc(context, debug, (void*)pcrtxxd_vector_new);
 
     return g_vld._new(pcrtxxd_vector_new, context, debug, size);
 }
@@ -942,7 +942,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd__scalar_new_dbg_4p (size_t       size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, type, file, line);
 }
@@ -970,7 +970,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd__scalar_new_dbg_3p (size_t       size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, file, line);
 }
@@ -1001,7 +1001,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd__vector_new_dbg_4p (size_t       size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, type, file, line);
 }
@@ -1029,7 +1029,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd__vector_new_dbg_3p (size_t       size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, file, line);
 }
@@ -1050,7 +1050,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd_scalar_new (size_t size)
     assert(pmfcxxd_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd_new);
+    CaptureContext cc(context, debug, (void*)pmfcxxd_new);
 
     return g_vld._new(pmfcxxd_new, context, debug, size);
 }
@@ -1071,7 +1071,7 @@ void* MfcPatch<CRTVersion, debug>::mfcd_vector_new (size_t size)
     assert(pmfcxxd_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd_new);
+    CaptureContext cc(context, debug, (void*)pmfcxxd_new);
 
     return g_vld._new(pmfcxxd_new, context, debug, size);
 }
@@ -1102,7 +1102,7 @@ void* MfcPatch<CRTVersion, debug>::mfcud__scalar_new_dbg_4p (size_t      size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, type, file, line);
 }
@@ -1130,7 +1130,7 @@ void* MfcPatch<CRTVersion, debug>::mfcud__scalar_new_dbg_3p (size_t      size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, file, line);
 }
@@ -1161,7 +1161,7 @@ void* MfcPatch<CRTVersion, debug>::mfcud__vector_new_dbg_4p (size_t      size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, type, file, line);
 }
@@ -1189,7 +1189,7 @@ void* MfcPatch<CRTVersion, debug>::mfcud__vector_new_dbg_3p (size_t      size,
     assert(pmfcxxd__new_dbg);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd__new_dbg);
+    CaptureContext cc(context, debug, (void*)pmfcxxd__new_dbg);
 
     return g_vld.__new_dbg_mfc(pmfcxxd__new_dbg, context, size, file, line);
 }
@@ -1210,7 +1210,7 @@ void* MfcPatch<CRTVersion, debug>::mfcud_scalar_new (size_t size)
     assert(pmfcxxd_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd_new);
+    CaptureContext cc(context, debug, (void*)pmfcxxd_new);
 
     return g_vld._new(pmfcxxd_new, context, debug, size);
 }
@@ -1231,56 +1231,38 @@ void* MfcPatch<CRTVersion, debug>::mfcud_vector_new (size_t size)
     assert(pmfcxxd_new);
 
     context_t context;
-    CAPTURE_CONTEXT(context, pmfcxxd_new);
+    CaptureContext cc(context, debug, (void*)pmfcxxd_new);
 
     return g_vld._new(pmfcxxd_new, context, debug, size);
 }
 
 // Visual Studio 6.0
-typedef CrtPatch<60>
-    VS60;
-typedef CrtPatch<60, true>
-    VS60d;
+typedef CrtPatch<60>        VS60;
+typedef CrtPatch<60, true>  VS60d;
 // Visual Studio .NET 2002
-typedef CrtPatch<70>
-    VS70;
-typedef CrtPatch<70, true>
-    VS70d;
+typedef CrtPatch<70>        VS70;
+typedef CrtPatch<70, true>  VS70d;
 // Visual Studio .NET 2003
-typedef CrtPatch<71>
-    VS71;
-typedef CrtPatch<71, true>
-    VS71d;
+typedef CrtPatch<71>        VS71;
+typedef CrtPatch<71, true>  VS71d;
 // Visual Studio 2005
-typedef CrtPatch<80>
-    VS80;
-typedef CrtPatch<80, true>
-    VS80d;
+typedef CrtPatch<80>        VS80;
+typedef CrtPatch<80, true>  VS80d;
 // Visual Studio 2008
-typedef CrtPatch<90>
-    VS90;
-typedef CrtPatch<90, true>
-    VS90d;
+typedef CrtPatch<90>        VS90;
+typedef CrtPatch<90, true>  VS90d;
 // Visual Studio 2010
-typedef CrtPatch<100>
-    VS100;
-typedef CrtPatch<100, true>
-    VS100d;
+typedef CrtPatch<100>       VS100;
+typedef CrtPatch<100, true> VS100d;
 // Visual Studio 2012
-typedef CrtPatch<110>
-    VS110;
-typedef CrtPatch<110, true>
-    VS110d;
+typedef CrtPatch<110>       VS110;
+typedef CrtPatch<110, true> VS110d;
 // Visual Studio 2013
-typedef CrtPatch<120>
-    VS120;
-typedef CrtPatch<120, true>
-    VS120d;
+typedef CrtPatch<120>       VS120;
+typedef CrtPatch<120, true> VS120d;
 // Visual Studio 2015 and higher
-typedef CrtPatch<140>
-    UCRT;
-typedef CrtPatch<140, true>
-    UCRTd;
+typedef CrtPatch<140>       UCRT;
+typedef CrtPatch<140, true> UCRTd;
 
 VS60    VS60::data;
 VS60d   VS60d::data;
@@ -1303,50 +1285,32 @@ UCRTd  UCRTd::data;
 
 
 // Visual Studio 6.0
-typedef MfcPatch<60>
-    Mfc60;
-typedef MfcPatch<60, true>
-    Mfc60d;
+typedef MfcPatch<60>        Mfc60;
+typedef MfcPatch<60, true>  Mfc60d;
 // Visual Studio .NET 2002
-typedef MfcPatch<70>
-    Mfc70;
-typedef MfcPatch<70, true>
-    Mfc70d;
+typedef MfcPatch<70>        Mfc70;
+typedef MfcPatch<70, true>  Mfc70d;
 // Visual Studio .NET 2003
-typedef MfcPatch<71>
-    Mfc71;
-typedef MfcPatch<71, true>
-    Mfc71d;
+typedef MfcPatch<71>        Mfc71;
+typedef MfcPatch<71, true>  Mfc71d;
 // Visual Studio 2005
-typedef MfcPatch<80>
-    Mfc80;
-typedef MfcPatch<80, true>
-    Mfc80d;
+typedef MfcPatch<80>        Mfc80;
+typedef MfcPatch<80, true>  Mfc80d;
 // Visual Studio 2008
-typedef MfcPatch<90>
-    Mfc90;
-typedef MfcPatch<90, true>
-    Mfc90d;
+typedef MfcPatch<90>        Mfc90;
+typedef MfcPatch<90, true>  Mfc90d;
 // Visual Studio 2010
-typedef MfcPatch<100>
-    Mfc100;
-typedef MfcPatch<100, true>
-    Mfc100d;
+typedef MfcPatch<100>       Mfc100;
+typedef MfcPatch<100, true> Mfc100d;
 // Visual Studio 2012
-typedef MfcPatch<110>
-    Mfc110;
-typedef MfcPatch<110, true>
-    Mfc110d;
+typedef MfcPatch<110>       Mfc110;
+typedef MfcPatch<110, true> Mfc110d;
 // Visual Studio 2013
-typedef MfcPatch<120>
-    Mfc120;
-typedef MfcPatch<120, true>
-    Mfc120d;
+typedef MfcPatch<120>       Mfc120;
+typedef MfcPatch<120, true> Mfc120d;
 // Visual Studio 2015
-typedef MfcPatch<140>
-    Mfc140;
-typedef MfcPatch<140, true>
-    Mfc140d;
+typedef MfcPatch<140>       Mfc140;
+typedef MfcPatch<140, true> Mfc140d;
 
 Mfc60     Mfc60::data;
 Mfc60d    Mfc60d::data;

--- a/src/dllspatches.cpp
+++ b/src/dllspatches.cpp
@@ -374,13 +374,13 @@ static patchentry_t msvcrtPatch [] = {
     "_malloc_dbg",        &VS60::data.pcrtd__malloc_dbg,       VS60::crtd__malloc_dbg,
     "_realloc_dbg",       &VS60::data.pcrtd__realloc_dbg,      VS60::crtd__realloc_dbg,
     scalar_new_dbg_name,  &VS60::data.pcrtd__scalar_new_dbg,    VS60::crtd__scalar_new_dbg,
-    //vector_new_dbg_name,  &VS60::data.pcrtd__vector_new_dbg,    VS60::crtd__vector_new_dbg,
+    vector_new_dbg_name,  &VS60::data.pcrtd__vector_new_dbg,    VS60::crtd__vector_new_dbg,
     "calloc",             &VS60::data.pcrtd_calloc,             VS60::crtd_calloc,
     "malloc",             &VS60::data.pcrtd_malloc,             VS60::crtd_malloc,
     "realloc",            &VS60::data.pcrtd_realloc,            VS60::crtd_realloc,
     "_strdup",            &VS60::data.pcrtd__strdup,            VS60::crtd__strdup,
     scalar_new_name,      &VS60::data.pcrtd_scalar_new,         VS60::crtd_scalar_new,
-    //vector_new_name,      &VS60::data.pcrtd_vector_new,         VS60::crtd_vector_new,
+    vector_new_name,      &VS60::data.pcrtd_vector_new,         VS60::crtd_vector_new,
     NULL,                 NULL,                                 NULL
 };
 
@@ -389,13 +389,13 @@ static patchentry_t msvcrtdPatch [] = {
     "_malloc_dbg",        &VS60d::data.pcrtd__malloc_dbg,       VS60d::crtd__malloc_dbg,
     "_realloc_dbg",       &VS60d::data.pcrtd__realloc_dbg,      VS60d::crtd__realloc_dbg,
     scalar_new_dbg_name,  &VS60d::data.pcrtd__scalar_new_dbg,   VS60d::crtd__scalar_new_dbg,
-    //vector_new_dbg_name,  &VS60d::data.pcrtd__vector_new_dbg,   VS60d::crtd__vector_new_dbg,
+    vector_new_dbg_name,  &VS60d::data.pcrtd__vector_new_dbg,   VS60d::crtd__vector_new_dbg,
     "calloc",             &VS60d::data.pcrtd_calloc,            VS60d::crtd_calloc,
     "malloc",             &VS60d::data.pcrtd_malloc,            VS60d::crtd_malloc,
     "realloc",            &VS60d::data.pcrtd_realloc,           VS60d::crtd_realloc,
     "_strdup",            &VS60d::data.pcrtd__strdup,           VS60d::crtd__strdup,
     scalar_new_name,      &VS60d::data.pcrtd_scalar_new,        VS60d::crtd_scalar_new,
-    //vector_new_name,      &VS60d::data.pcrtd_vector_new,        VS60d::crtd_vector_new,
+    vector_new_name,      &VS60d::data.pcrtd_vector_new,        VS60d::crtd_vector_new,
     NULL,                 NULL,                                 NULL
 };
 

--- a/src/tests/vld_main/vld_main.cpp
+++ b/src/tests/vld_main/vld_main.cpp
@@ -48,8 +48,9 @@ int Test()
     // including a leak for ml which has not been freed yet. ml will be freed after
     // _tmain exits but before VLDReportLeaks() is called internally by VLD and
     // therefore correctly report 8 leaks.
-    // VLDReportLeaks(); // at this point should report 9 leaks;
-    return VLDGetLeaksCount();
+    int leaks = VLDGetLeaksCount();
+    VLDReportLeaks(); // at this point should report 9 leaks;
+    return leaks;
 }
 
 int _tmain(int argc, _TCHAR* argv[])

--- a/src/tests/vld_unload/vld_unload.cpp
+++ b/src/tests/vld_unload/vld_unload.cpp
@@ -71,6 +71,10 @@ TEST(TestUnloadDlls, Sequence2)
     ::FreeLibrary(hModule4);    // vld is *not* unloaded here
     int y = VLDGetLeaksCount();
 #if _MSC_VER <= 1600 && !defined(_DLL) // VS 2010 and bellow
+    // The reason for reporting 1 leak at this point is that the vld_dll1 module build with <VS2013 calls internally
+    // HeapDestroy when it unloads and the leak is either
+    // - reported automatically by VLD when the Heap is destroyed if VLD_OPT_SKIP_HEAPFREE_LEAKS was specified or
+    // - ignored since the destroyed Heap was removed from VLD heap map.
     EXPECT_EQ(1, y); // vld is still loaded and counts 1 memory leaks
 #else
     EXPECT_EQ(2, y); // vld is still loaded and counts 2 memory leaks
@@ -92,6 +96,10 @@ TEST(TestUnloadDlls, Sequence3)
     ::FreeLibrary(hModule5);    // vld is *not* unloaded here
     int y = VLDGetLeaksCount(); // vld is still loaded and counts 2 memory leaks
 #if _MSC_VER <= 1600 && !defined(_DLL) // VS 2010 and bellow
+    // The reason for reporting 1 leak at this point is that the vld_dll1 module build with <VS2013 calls internally
+    // HeapDestroy when it unloads and the leak is either
+    // - reported automatically by VLD when the Heap is destroyed if VLD_OPT_SKIP_HEAPFREE_LEAKS was specified or
+    // - ignored since the destroyed Heap was removed from VLD heap map.
     EXPECT_EQ(1, y); // vld is still loaded and counts 1 memory leaks
 #else
     EXPECT_EQ(2, y); // vld is still loaded and counts 2 memory leaks

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -1707,10 +1707,14 @@ SIZE_T VisualLeakDetector::getLeaksCount (heapinfo_t* heapinfo, DWORD threadId)
                 // This block is marked as being used internally by the CRT.
                 // The CRT will free the block after VLD is destroyed.
                 continue;
+             } else if (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS) {
+                 // Check for crt startup allocations
+                 if (info->callStack && info->callStack->isCrtStartupAlloc()) {
+                     info->reported = true;
+                     continue;
+                 }
             }
-        }
-
-        if (!info->debugCrtAlloc && (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS)) {
+        } else if (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS) {
             // Check for crt startup allocations
             if (info->callStack && info->callStack->isCrtStartupAlloc()) {
                 info->reported = true;
@@ -1804,16 +1808,21 @@ SIZE_T VisualLeakDetector::reportLeaks (heapinfo_t* heapinfo, bool &firstLeak, S
                 // This block is marked as being used internally by the CRT.
                 // The CRT will free the block after VLD is destroyed.
                 continue;
+             } else if (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS) {
+                 // Check for crt startup allocations
+                 if (info->callStack && info->callStack->isCrtStartupAlloc()) {
+                     info->reported = true;
+                     continue;
+                 }
             }
+
             // The CRT header is more or less transparent to the user, so
             // the information about the contained block will probably be
             // more useful to the user. Accordingly, that's the information
             // we'll include in the report.
             address = CRTDBGBLOCKDATA(block);
             size = crtheader->size;
-        }
-
-        if (!info->debugCrtAlloc && (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS)) {
+        } else if (m_options & VLD_OPT_SKIP_CRTSTARTUP_LEAKS) {
             // Check for crt startup allocations
             if (info->callStack && info->callStack->isCrtStartupAlloc()) {
                 info->reported = true;

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -2283,13 +2283,6 @@ VOID VisualLeakDetector::RefreshModules()
     delete oldmodules;
 }
 
-void VisualLeakDetector::getCallStack( CallStack *&pcallstack, context_t &context )
-{
-    CallStack* callstack = CallStack::Create();
-    pcallstack = callstack;
-    callstack->getStackTrace(g_vld.m_maxTraceFrames, context);
-}
-
 // Find the information for the module that initiated this reallocation.
 bool VisualLeakDetector::isModuleExcluded(UINT_PTR address)
 {
@@ -2811,4 +2804,93 @@ int VisualLeakDetector::ResolveCallstacks()
         unresolvedFunctionsCount += resolveStacks(heapinfo);
     }
     return unresolvedFunctionsCount;
+}
+
+
+CaptureContext::CaptureContext(context_t &context, BOOL debug, void* func, UINT_PTR fp) : m_func(func), m_fp(fp) {
+    m_tls = g_vld.getTls();
+
+    if (debug) {
+        m_tls->flags |= VLD_TLS_DEBUGCRTALLOC;
+    }
+
+    m_bFirst = (GET_RETURN_ADDRESS(m_tls->context) == NULL);
+    m_bExclude = g_vld.isModuleExcluded(fp);
+    if (m_bFirst) {
+        // This is the first call to enter VLD for the current allocation.
+        // Record the current frame pointer.
+        if (func) {
+            Capture(context);
+        }
+        m_tls->context = context;
+    }
+}
+
+CaptureContext::~CaptureContext() {
+    if (m_bFirst) {
+        if ((!m_bExclude) && (m_tls->blockWithoutGuard)) {
+            blockinfo_t* pblockInfo = NULL;
+            if (m_tls->newBlockWithoutGuard == NULL) {
+                g_vld.mapBlock(m_tls->heap,
+                    m_tls->blockWithoutGuard,
+                    m_tls->size,
+                    (m_tls->flags & VLD_TLS_DEBUGCRTALLOC),
+                    m_tls->threadId,
+                    pblockInfo);
+            } else {
+                g_vld.remapBlock(m_tls->heap,
+                    m_tls->blockWithoutGuard,
+                    m_tls->newBlockWithoutGuard,
+                    m_tls->size,
+                    (m_tls->flags & VLD_TLS_DEBUGCRTALLOC),
+                    m_tls->threadId,
+                    pblockInfo, m_tls->context);
+            }
+
+            CallStack* callstack = CallStack::Create();
+            callstack->getStackTrace(g_vld.m_maxTraceFrames, m_tls->context);
+            pblockInfo->callStack.reset(callstack);
+        }
+
+        // Reset thread local flags and variables for the next allocation.
+        Reset();
+    }
+}
+
+void CaptureContext::Capture(context_t &context) {
+    context.fp = m_fp;
+    context.func = (UINT_PTR)(m_func);
+
+    CONTEXT _ctx;
+    RtlCaptureContext(&_ctx);
+#if defined(_M_IX86)
+    context.Ebp = _ctx.Ebp; context.Esp = _ctx.Esp; context.Eip = _ctx.Eip;
+#elif defined(_M_X64)
+    context.Rbp = _ctx.Rbp; context.Rsp = _ctx.Rsp; context.Rip = _ctx.Rip;
+#else
+    // If you want to retarget Visual Leak Detector to another processor
+    // architecture then you'll need to provide an architecture-specific macro to
+    // obtain the frame pointer (or other address) which can be used to obtain the
+    // return address and stack pointer of the calling frame.
+#error "Visual Leak Detector is not supported on this architecture."
+#endif // _M_IX86 || _M_X64
+}
+
+void CaptureContext::Set(HANDLE heap, LPVOID mem, LPVOID newmem, SIZE_T size) {
+    m_tls->heap = heap;
+    m_tls->blockWithoutGuard = mem;
+    m_tls->newBlockWithoutGuard = newmem;
+    m_tls->size = size;
+
+    if ((m_tls->blockWithoutGuard) && (g_vld.m_options & VLD_OPT_TRACE_INTERNAL_FRAMES)) {
+        // If VLD_OPT_TRACE_INTERNAL_FRAMES is specified then we capture the frame pointer upto the function that acutally
+        // performs the allocation to the heap being: HeapAlloc, HeapReAlloc, RtlAllocateHeap, RtlReAllocateHeap.
+        Capture(m_tls->context);
+    }
+}
+
+void CaptureContext::Reset() {
+    m_tls->context = { NULL };
+    m_tls->flags &= ~VLD_TLS_DEBUGCRTALLOC;
+    Set(NULL, NULL, NULL, NULL);
 }

--- a/src/vld_hooks.cpp
+++ b/src/vld_hooks.cpp
@@ -865,7 +865,7 @@ void* VisualLeakDetector::__new_dbg_mfc (new_dbg_crt_t  pnew_dbg,
 #ifdef PRINTHOOKCALLS
     DbgReport(_T(__FUNCTION__) _T( "\n"));
 #endif
-    CaptureContext cc(context, TRUE, NULL);
+    CaptureContext cc(context, FALSE, NULL);
 
     // Do the allocation. The block will be mapped by _RtlAllocateHeap.
     return pnew_dbg(size, type, file, line);
@@ -900,7 +900,7 @@ void* VisualLeakDetector::__new_dbg_mfc (new_dbg_mfc_t  pnew_dbg_mfc,
 #ifdef PRINTHOOKCALLS
     DbgReport(_T(__FUNCTION__) _T( "\n"));
 #endif
-    CaptureContext cc(context, TRUE, NULL);
+    CaptureContext cc(context, FALSE, NULL);
 
     // Do the allocation. The block will be mapped by _RtlAllocateHeap.
     return pnew_dbg_mfc(size, file, line);

--- a/src/vldint.h
+++ b/src/vldint.h
@@ -194,6 +194,7 @@ private:
     CaptureContext& operator=(const CaptureContext&);
 private:
     __forceinline void Capture(context_t &context);
+    BOOL IsExcludedModule();
     void Reset();
 private:
     tls_t *m_tls;
@@ -430,6 +431,7 @@ private:
     CriticalSection      m_tlsLock;           // Protects accesses to the Set of TLS structures.
     TlsMap              *m_tlsMap;            // Set of all thread-local storage structures for the process.
     HMODULE              m_vldBase;           // Visual Leak Detector's own module handle (base address).
+    HMODULE              m_dbghlpBase;
 
     VOID __stdcall ChangeModuleState(HMODULE module, bool on);
     static GetProcAddress_t m_GetProcAddress;

--- a/src/vldint.h
+++ b/src/vldint.h
@@ -186,14 +186,15 @@ class CaptureContext {
 public:
     CaptureContext(context_t &context, BOOL debug, void* func, UINT_PTR fp = (UINT_PTR)_ReturnAddress());
     ~CaptureContext();
-    void Set(HANDLE heap, LPVOID mem, LPVOID newmem, SIZE_T size);
-    void Reset();
+    __forceinline void Set(HANDLE heap, LPVOID mem, LPVOID newmem, SIZE_T size);
 private:
     // Disallow certain operations
     CaptureContext();
     CaptureContext(const CaptureContext&);
     CaptureContext& operator=(const CaptureContext&);
-    inline void Capture(context_t &context);
+private:
+    __forceinline void Capture(context_t &context);
+    void Reset();
 private:
     tls_t *m_tls;
     BOOL m_bFirst;


### PR DESCRIPTION
Document special case in vld_unload test
Enable capturing vector_new... in msvcrtPatch
Skip stack trace for frames internal to vld
Use CaptureContext class to simplify code in hooks