### PR TITLE
enhancement: make vld preserve GetLastError/WSAGetLastError state

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+
 #include <cassert>
 #include <cerrno>
 #include <cstdio>

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -42,6 +42,7 @@
 #define HEAP_MAP_RESERVE    2   // Usually there won't be more than a few heaps in the process, so this should be small.
 #define MODULE_SET_RESERVE  16  // There are likely to be several modules loaded in the process.
 
+#define PRESERVE_LASTERROR      // if defined preserves status of GetLastError
 #define PRESERVE_WSAERROR       // if defined preserves status of WSAGetLastError
 
 // Imported global variables.
@@ -1297,14 +1298,20 @@ tls_t* VisualLeakDetector::getTls ()
 {
 #if defined(PRESERVE_WSAERROR)
     // save winsock last error because TlsGetValue resets it
-    // perhaps we should do the same wit lasterror ?
     int wsaerrpre = WSAGetLastError(); 
+#endif    
+#if defined(PRESERVE_LASTERROR)
+    // save last error because TlsGetValue resets it
+    int errpre = GetLastError(); 
 #endif    
 
     // Get the pointer to this thread's thread local storage structure.
     tls_t* tls = (tls_t*)TlsGetValue(m_tlsIndex);
     assert(GetLastError() == ERROR_SUCCESS);
 
+#if defined(PRESERVE_LASTERROR)
+    SetLastError(errpre); // restore previous state of error
+#endif    
 #if defined(PRESERVE_WSAERROR)
     WSASetLastError(wsaerrpre); // restore previous state of ws error
 #endif    

--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -42,6 +42,8 @@
 #define HEAP_MAP_RESERVE    2   // Usually there won't be more than a few heaps in the process, so this should be small.
 #define MODULE_SET_RESERVE  16  // There are likely to be several modules loaded in the process.
 
+#define PRESERVE_WSAERROR       // if defined preserves status of WSAGetLastError
+
 // Imported global variables.
 extern vldblockheader_t *g_vldBlockList;
 extern HANDLE            g_vldHeap;
@@ -1293,9 +1295,19 @@ SIZE_T VisualLeakDetector::eraseDuplicates (const BlockMap::Iterator &element, S
 //
 tls_t* VisualLeakDetector::getTls ()
 {
+#if defined(PRESERVE_WSAERROR)
+    // save winsock last error because TlsGetValue resets it
+    // perhaps we should do the same wit lasterror ?
+    int wsaerrpre = WSAGetLastError(); 
+#endif    
+
     // Get the pointer to this thread's thread local storage structure.
     tls_t* tls = (tls_t*)TlsGetValue(m_tlsIndex);
     assert(GetLastError() == ERROR_SUCCESS);
+
+#if defined(PRESERVE_WSAERROR)
+    WSASetLastError(wsaerrpre); // restore previous state of ws error
+#endif    
 
     if (tls == NULL) {
         DWORD threadId = GetCurrentThreadId();


### PR DESCRIPTION
VLD calls TlsGetValue() and that resets both GetLastError and WSAGetLastError values.
This patch preserves both values between getTls() calls

fixes also codeplex issue 10586 (http://vld.codeplex.com/workitem/10586)
