### PR TITLE
fix: blockinfo can be changed after being extracted

### DIFF
--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -350,6 +350,7 @@ VisualLeakDetector::VisualLeakDetector ()
     m_reportFile     = NULL;
     wcsncpy_s(m_reportFilePath, MAX_PATH, VLD_DEFAULT_REPORT_FILE_NAME, _TRUNCATE);
     m_status         = 0x0;
+    m_optionsLock.Initialize();
 
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
     if (ntdll)
@@ -420,7 +421,6 @@ VisualLeakDetector::VisualLeakDetector ()
     m_curAlloc        = 0;
     m_maxAlloc        = 0;
     m_loadedModules   = new ModuleSet();
-    m_optionsLock.Initialize();
     m_modulesLock.Initialize();
     m_selfTestFile    = __FILE__;
     m_selfTestLine    = 0;
@@ -1346,8 +1346,6 @@ tls_t* VisualLeakDetector::getTls ()
 //
 VOID VisualLeakDetector::mapBlock (HANDLE heap, LPCVOID mem, SIZE_T size, bool debugcrtalloc, bool ucrt, DWORD threadId, blockinfo_t* &pblockInfo)
 {
-    CriticalSectionLocker<> cs(g_heapMapLock);
-
     // Record the block's information.
     blockinfo_t* blockinfo = new blockinfo_t();
     blockinfo->callStack = NULL;
@@ -1562,8 +1560,6 @@ VOID VisualLeakDetector::unmapHeap (HANDLE heap)
 VOID VisualLeakDetector::remapBlock (HANDLE heap, LPCVOID mem, LPCVOID newmem, SIZE_T size,
     bool debugcrtalloc, bool ucrt, DWORD threadId, blockinfo_t* &pblockInfo, const context_t &context)
 {
-    CriticalSectionLocker<> cs(g_heapMapLock);
-
     if (newmem != mem) {
         // The block was not reallocated in-place. Instead the old block was
         // freed and a new block allocated to satisfy the new size.
@@ -2925,6 +2921,11 @@ CaptureContext::~CaptureContext() {
         return;
 
     if ((m_tls->blockWithoutGuard) && (!IsExcludedModule())) {
+        CallStack* callstack = CallStack::Create();
+        callstack->getStackTrace(g_vld.m_maxTraceFrames, m_tls->context);
+
+        CriticalSectionLocker<> cs(g_heapMapLock);
+
         blockinfo_t* pblockInfo = NULL;
         if (m_tls->newBlockWithoutGuard == NULL) {
             g_vld.mapBlock(m_tls->heap,
@@ -2946,8 +2947,6 @@ CaptureContext::~CaptureContext() {
                 pblockInfo, m_tls->context);
         }
 
-        CallStack* callstack = CallStack::Create();
-        callstack->getStackTrace(g_vld.m_maxTraceFrames, m_tls->context);
         pblockInfo->callStack.reset(callstack);
     }
 


### PR DESCRIPTION
~CaptureContext obtains a blockinfo_t from map/remapBlock, then adds callstack information to it.
But in multithreaded programs another thread could change blockinfo informations.
This patch moves locks on g_heapMapLock to ~CaptureContext and reorders callstack collection before the lock