### PR TITLE
fix: obtain ldrlock before dumping leaks, to avoid deadlocks

### DIFF
--- a/src/vld.cpp
+++ b/src/vld.cpp
@@ -2419,6 +2419,8 @@ SIZE_T VisualLeakDetector::ReportThreadLeaks( DWORD threadId )
         return 0;
     }
 
+    LoaderLock ll;  // scanning for module names needs ldrloc - getting it proactively to avoid deadlocks later
+
     // Generate a memory leak report for each heap in the process.
     SIZE_T leaksCount = 0;
     CriticalSectionLocker<> cs(g_heapMapLock);


### PR DESCRIPTION
While dumping leaks, vld calls GetModuleName during callstack resolving, but this function needs ldrlock.  
If other threads call functions taking ldrlock and also triggering vld code (e.g. module unloading) this leads to a deadlock. 
The thread dumping leaks has g_heapMapLock and wants ldrlock, while the other has ldrlock (usually obtained directly by the windows method) and wants g_heapMapLock.

This patch fixes this situation by just taking ldrlock before doing a leak dump