### PR TITLE
忽略STRUNCATE错误，避免无法输出调用堆栈

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ src/bin/vld.ini
 /src/tests/vld_ComTest/ComTest_i.c
 *.VC.opendb
 *.VC.db
+
+\.vs

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -717,7 +717,8 @@ VOID Print (LPWSTR messagew)
             const size_t MAXMESSAGELENGTH = 5119;
             size_t  count = 0;
             CHAR    messagea [MAXMESSAGELENGTH + 1];
-            if (wcstombs_s(&count, messagea, MAXMESSAGELENGTH + 1, messagew, _TRUNCATE) != 0) {
+            errno_t ret = wcstombs_s(&count, messagea, MAXMESSAGELENGTH + 1, messagew, _TRUNCATE);
+            if (ret != 0 && ret != STRUNCATE) {
                 // Failed to convert the Unicode message to ASCII.
                 assert(FALSE);
                 return;


### PR DESCRIPTION
当callstack大小超过MAXMESSAGELENGTH时，wcstombs_s会返回STRUNCATE，我们需要忽略这个错误码，否则无法输出callstack