### PR TITLE
Do not assert if message is truncated during print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/bin/vld.ini
 /src/tests/vld_ComTest/ComTest_p.c
 /src/tests/vld_ComTest/ComTest_i.c
 *.VC.opendb
+.vs

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -717,7 +717,8 @@ VOID Print (LPWSTR messagew)
             const size_t MAXMESSAGELENGTH = 5119;
             size_t  count = 0;
             CHAR    messagea [MAXMESSAGELENGTH + 1];
-            if (wcstombs_s(&count, messagea, MAXMESSAGELENGTH + 1, messagew, _TRUNCATE) != 0) {
+            errno_t ret = wcstombs_s(&count, messagea, MAXMESSAGELENGTH + 1, messagew, _TRUNCATE);
+            if (ret != 0 && ret != STRUNCATE) {
                 // Failed to convert the Unicode message to ASCII.
                 assert(FALSE);
                 return;


### PR DESCRIPTION
`wcstombs_s` does not return `0` when `count` is `_TRUNCATE` but rather `STRUNCATE` as seen [here](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/wcstombs-s-wcstombs-s-l?view=vs-2015). This pull request caters for this condition.